### PR TITLE
Add option to disable cron setup in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,38 @@
 #!/bin/bash
 
+# Initialize flag for cron setup to true (meaning by default cron will be set up)
+SETUP_CRON=true
+
+# Function to display help message
+display_help() {
+    echo "Usage: $0 [options]"
+    echo "  -n  Disable cron setup."
+    echo "  -h  Display this help message."
+}
+
+# Check for --help option
+if [[ " $* " == *" --help "* ]]; then
+    display_help
+    exit 0
+fi
+
+# Parse CLI arguments
+while getopts ":nh" opt; do
+    case ${opt} in
+    n) # process option n
+        SETUP_CRON=false
+        ;;
+    h) # process option h
+        display_help
+        exit 0
+        ;;
+    \?)
+        echo "Usage: $0 [-n (no cron setup)]"
+        exit 1
+        ;;
+    esac
+done
+
 # Welcome message
 echo "Welcome to the setup script for Prevent-OCI-Deletion-for-being-idle!"
 
@@ -50,7 +83,7 @@ echo "Moving the repo to $TARGET_DIR..."
 # Check if target dir is not empty
 if [ "$(ls -A "$TARGET_DIR")" ]; then
     echo "Target directory is not empty. Cleaning up..."
-    rm -f -r "${TARGET_DIR/*}"
+    rm -f -r "${TARGET_DIR/*/}"
 fi
 
 # Move content to location
@@ -59,17 +92,26 @@ mv "$HOME"/Prevent-OCI-Deletion-for-being-idle-stable/* "$TARGET_DIR"
 # Clean up files
 rm -f -r "$HOME/POCIDFBI.zip" "$HOME/Prevent-OCI-Deletion-for-being-idle-stable"
 
-# Set up cron
-# Backup the crontab first
-crontab -l > "$HOME/cron_backup.txt"
+# Set up cron only if SETUP_CRON is true
+if $SETUP_CRON; then
+    # Backup the crontab first
+    crontab -l >"$HOME/cron_backup.txt"
 
-# Check if the cron task already exists
-if grep -q "POCIDFBIManager.sh" "$HOME/cron_backup.txt"; then
-    echo "Cron task already exists. Skipping..."
+    # Check if the cron task already exists
+    if grep -q "POCIDFBIManager.sh" "$HOME/cron_backup.txt"; then
+        echo "Cron task already exists. Skipping..."
+    else
+        echo "Cron task does not exist. Adding..."
+        # Add the cron task without overwriting
+        (
+            crontab -l
+            echo "* * * * * /bin/bash $TARGET_DIR/POCIDFBIManager.sh"
+        ) | crontab -
+    fi
 else
-    echo "Cron task does not exist. Adding..."
-    # Add the cron task without overwriting
-    (crontab -l; echo "* * * * * /bin/bash $TARGET_DIR/POCIDFBIManager.sh") | crontab -
+    echo "Skipping cron setup as per user request."
+    echo "If you'd like to add the cron task manually later, here's the line you would add to your crontab:"
+    echo "* * * * * /bin/bash $TARGET_DIR/POCIDFBIManager.sh"
 fi
 
 echo "Setup complete!"


### PR DESCRIPTION
This adds the functionality to disable cron setup when running the install script. The user can now pass the "-n" option to prevent the cron task from being created. If the cron task does not exist and the user does not want to skip it, a message will be displayed with the command to manually add the cron task to the crontab.